### PR TITLE
Faceplate cleanup

### DIFF
--- a/hardware/control-pro/README.md
+++ b/hardware/control-pro/README.md
@@ -15,7 +15,7 @@ Sparkfun offers some, but not all, of the components required for the control-pr
 You can order the PCB from [OHS Park](https://oshpark.com/):
 
 - [Control: DMX-CPB 1.0](https://oshpark.com/shared_projects/JQNIThBR).
-- [Faceplate: DMX-CPF 1.0](https://oshpark.com/shared_projects/TtmIh4TS)
+- [Faceplate: DMX-CPF 1.1](https://oshpark.com/shared_projects/rXztu83J)
 - [Transmitter: DMX-TX2 1.0](https://oshpark.com/shared_projects/5JnCfRjj)
 
 ## Parts

--- a/hardware/control-pro/faceplate/CHANGELOG.md
+++ b/hardware/control-pro/faceplate/CHANGELOG.md
@@ -1,0 +1,11 @@
+# DMX Demonstrator Control-Pro Faceplate (DMX-CPF)
+
+## Changes
+
+### 1.1
+
+Removed copper from 3rd slider slot by enlarging slot width.
+
+### 1.0
+
+Initial version.

--- a/hardware/control-pro/faceplate/faceplate.kicad_pcb
+++ b/hardware/control-pro/faceplate/faceplate.kicad_pcb
@@ -13,7 +13,7 @@
   (title_block
     (title "DMX Demonstrator - Control-Pro Faceplate (DMX-CPF)")
     (date 2020-09-15)
-    (rev 1.0)
+    (rev 1.1)
     (company "Crazy Giraffe Software")
     (comment 2 "Designed by: SparkyBobo")
     (comment 3 https://creativecommons.org/licenses/by-sa/4.0/)
@@ -172,7 +172,7 @@
     (pad "" np_thru_hole circle (at 0 0) (size 6.2 6.2) (drill 6.2) (layers *.Cu *.Mask))
   )
 
-  (module MountingHole:MountingHole_3.2mm_M3 (layer F.Cu) (tedit 5F6FAEFE) (tstamp 5F71D0FD)
+  (module MountingHole:MountingHole_3.2mm_M3 (layer F.Cu) (tedit 5F70FC15) (tstamp 5F71D0FD)
     (at 184.25 100)
     (descr "Mounting Hole 3.2mm, no annular, M3")
     (tags "mounting hole 3.2mm no annular m3")
@@ -192,7 +192,7 @@
     (pad "" np_thru_hole oval (at 0 0.5) (size 2.6 60) (drill oval 2.6 60) (layers *.Cu *.Mask))
   )
 
-  (module MountingHole:MountingHole_3.2mm_M3 (layer F.Cu) (tedit 5F6FAF07) (tstamp 5F71D0F5)
+  (module MountingHole:MountingHole_3.2mm_M3 (layer F.Cu) (tedit 5F70FC95) (tstamp 5F71D0F5)
     (at 154 94.25)
     (descr "Mounting Hole 3.2mm, no annular, M3")
     (tags "mounting hole 3.2mm no annular m3")
@@ -209,10 +209,10 @@
     )
     (fp_circle (center 0 0) (end 3.2 0) (layer Cmts.User) (width 0.15))
     (fp_circle (center 0 0) (end 3.45 0) (layer F.CrtYd) (width 0.05))
-    (pad "" np_thru_hole oval (at 0 6.25) (size 2.6 60) (drill oval 2 60) (layers *.Cu *.Mask))
+    (pad "" np_thru_hole oval (at 0 6.25) (size 2.6 60) (drill oval 2.6 60) (layers *.Cu *.Mask))
   )
 
-  (module MountingHole:MountingHole_3.2mm_M3 (layer F.Cu) (tedit 5F6FAF19) (tstamp 5F71D203)
+  (module MountingHole:MountingHole_3.2mm_M3 (layer F.Cu) (tedit 5F70FBBC) (tstamp 5F71D203)
     (at 124 94.25)
     (descr "Mounting Hole 3.2mm, no annular, M3")
     (tags "mounting hole 3.2mm no annular m3")
@@ -2452,7 +2452,7 @@
   (gr_text Clock (at 214 78) (layer F.SilkS)
     (effects (font (size 1.5 1.5) (thickness 0.3)))
   )
-  (gr_text "DMX-CPF, Rev 1.0\nCrazy Giraffe Software" (at 240.75 72.25 90) (layer B.SilkS)
+  (gr_text "DMX-CPF, Rev 1.1\nCrazy Giraffe Software" (at 240.75 72.25 90) (layer B.SilkS)
     (effects (font (size 1 1) (thickness 0.15)) (justify mirror))
   )
   (gr_text Fast (at 204 80.25) (layer F.SilkS)

--- a/hardware/control-pro/faceplate/faceplate.sch
+++ b/hardware/control-pro/faceplate/faceplate.sch
@@ -7,7 +7,7 @@ encoding utf-8
 Sheet 1 1
 Title "DMX Demonstrator - Control-Pro Faceplate (DMX-CPF)"
 Date "2020-09-15"
-Rev "1.0"
+Rev "1.1"
 Comp "Crazy Giraffe Software"
 Comment1 ""
 Comment2 "Designed by: SparkyBobo"

--- a/hardware/receiver/README.md
+++ b/hardware/receiver/README.md
@@ -14,4 +14,4 @@ Additionally, you'll need some parts from the common parts lists as well. You ca
 
 You can order the PCB from [OHS Park](https://oshpark.com/):
 
-- [DMX-RX1](https://oshpark.com/shared_projects/IDtKKv4v).
+- [DMX-RX1 1.0](https://oshpark.com/shared_projects/IDtKKv4v).

--- a/hardware/transmitter/README.md
+++ b/hardware/transmitter/README.md
@@ -19,4 +19,4 @@ Note: The rotary potentiometer offered by sparkfun stands a total of 30mm from t
 
 You can order the PCB from [OHS Park](https://oshpark.com/):
 
-- [DMX-TX1](https://oshpark.com/shared_projects/dOW0ooLv)
+- [DMX-TX1 1.0](https://oshpark.com/shared_projects/dOW0ooLv)


### PR DESCRIPTION
Enlarge slot for slider #3 to remove copper from faceplate.
Ensure all OHS parks links include a revision number.

Fixes #3 