### PR TITLE
TX and RX 1.1 software fixes

### DIFF
--- a/branches.txt
+++ b/branches.txt
@@ -1,0 +1,35 @@
+users/sparky/txrx12 - hw, already merged
+
+users/sparky/discovery -> PR
+users/sparky/tx-refactor -> PR
+users/sparky/rx-refactor -> PR
+
+desktop - Basic desktop
+desktopAndSketch - Desktop with above PRs and tweaks
+
+users/sparky/controlPro11 - New control pro
+users/sparky/tx-pro-multi-sheet - New tx pro
+users/sparky/rx-pro-multi-sheet - New rx pro
+  - Core needs work
+     - rx1-3a looks good
+     - rx1-3b neds work
+  - display is copy of rx-pro
+  - start-code is copy of rx-pro
+
+
+Rx shift goals
+reset at frame reset
+start counting when 0 is on data line
+on the 9th clock pulse, load shifted + data bit if shifted highest bit is 0.
+on the 11th clock pulse, data is valid if data bit + shifted lowest bits are 1
+on the 11th clock pulse, reset. 
+
+shift data available 40ns after clock pulses high
+latch data on 1001
+check stop bits on 1011
+the problem with shift is I don't want the incoming data to impact the decision
+so must check it on rising edge only, so before shift, or latch it and falling edge
+So if 9, latch data into buffer. Orig used to drive this onto the bus feeding into secondary latches
+So if 11, decide to latch the bus to secondary latches based on stop bits.
+
+

--- a/software/transmitter/FixedTimer2.h
+++ b/software/transmitter/FixedTimer2.h
@@ -44,8 +44,8 @@ class FixedTimer2 {
         TCCR3C = 0;                   // Reset Timer 3 control register C.
         TCNT3  = 0;                   // Reset timer 3 counter value.
 
-        clockSelect = (1 << CS30);    // Clock source is F_CPU.
-        clockCount = 64;              // Maps to about 250kHz for F_CPU==16Mhz
+        clockSelect = (1 << CS30);    // Clock source is F_CPU / 8.
+        clockCount = 64;              // Maps to about 62.5kHz for F_CPU==16Mhz
 #else
         TCCR2A = 0;                   // Reset Timer 2 control register A.
         TCCR2B = 0;                   // Reset Timer 2 control register B.
@@ -53,7 +53,7 @@ class FixedTimer2 {
         TCCR2A = (1 << WGM21);        // CTC mode: count to OCR1A, clear clock source.
 
         clockSelect = _BV(CS21);      // Clock source is F_CPU / 8.
-        clockCount = 8;               // Maps to about 250kHz for F_CPU==16Mhz
+        clockCount = 32;              // Maps to about 62.5kHz for F_CPU==16Mhz
 #endif
 
         Stop();


### PR DESCRIPTION
- Slow down analog read clock
- Fix bug on TX1 where dimmer value was written to all dimmers, not the selected dimmer
- Fix bug where clock speed was using byte math instead of long math due to #define
- Avoid going into error state when stream is in break at expected time
- Disable verbose mode when the clock is too fast to keep up with writing the verbose output